### PR TITLE
add persisted run logs

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -53,6 +53,13 @@ module MaintenanceTasks
       redirect_to(task_path(@run.task_name), alert: error.message)
     end
 
+    # Displays the logs for a given Run.
+    def logs
+      logs = @run.log&.content || ["No logs available"]
+
+      render plain: logs.join("\n")
+    end
+
     private
 
     def set_run

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -109,7 +109,10 @@ module MaintenanceTasks
 
     def before_perform
       @run = arguments.first
+      @run.log_buffer = []
       @task = @run.task
+      @task.run = @run
+
       if @task.has_csv_content?
         @task.csv_content = @run.csv_file.download
       end

--- a/app/models/maintenance_tasks/log.rb
+++ b/app/models/maintenance_tasks/log.rb
@@ -1,0 +1,7 @@
+module MaintenanceTasks
+  class Log < ApplicationRecord
+    belongs_to :run, class_name: "MaintenanceTasks::Run", inverse_of: :log
+
+    serialize :content, JSON
+  end
+end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -11,6 +11,8 @@ module MaintenanceTasks
 
     class NotFoundError < NameError; end
 
+    attr_accessor :run
+
     # The throttle conditions for a given Task. This is provided as an array of
     # hashes, with each hash specifying two keys: throttle_condition and
     # backoff. Note that Tasks inherit conditions from their superclasses.
@@ -252,6 +254,12 @@ module MaintenanceTasks
     # @return [Integer, nil]
     def count
       self.class.collection_builder_strategy.count(self)
+    end
+
+    def log(message)
+      raise "Task#log must be called within a run context" unless run
+
+      run.append_log(message)
     end
   end
 end

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -14,6 +14,10 @@
     <%= render "maintenance_tasks/runs/info/custom", run: run %>
   </div>
 
+  <div class="content">
+    <%= link_to "Show logs", logs_task_run_path(@task, run) %>
+  </div>
+
   <%= render "maintenance_tasks/runs/csv", run: run %>
   <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
   <%= render "maintenance_tasks/runs/arguments", run: run %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ MaintenanceTasks::Engine.routes.draw do
         put "pause"
         put "cancel"
         put "resume"
+        get "logs"
       end
     end
   end

--- a/db/migrate/20230911113130_create_maintenance_tasks_logs.rb
+++ b/db/migrate/20230911113130_create_maintenance_tasks_logs.rb
@@ -1,0 +1,10 @@
+class CreateMaintenanceTasksLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :maintenance_tasks_logs do |t|
+      t.references :run, null: false, foreign_key: {to_table: :maintenance_tasks_runs, on_delete: :cascade}
+      t.text :content, null: false, default: [].to_json
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/app/tasks/maintenance/persist_run_logs_task.rb
+++ b/test/dummy/app/tasks/maintenance/persist_run_logs_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class PersistRunLogsTask < MaintenanceTasks::Task
+    def collection
+      [1, 2, 3]
+    end
+
+    def process(number)
+      log("number: #{number}")
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_22_035229) do
+ActiveRecord::Schema.define(version: 2023_09_11_113130) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -37,6 +37,14 @@ ActiveRecord::Schema.define(version: 2023_06_22_035229) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "maintenance_tasks_logs", force: :cascade do |t|
+    t.integer "run_id", null: false
+    t.text "content", default: "[]", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["run_id"], name: "index_maintenance_tasks_logs_on_run_id"
   end
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
@@ -69,4 +77,5 @@ ActiveRecord::Schema.define(version: 2023_06_22_035229) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "maintenance_tasks_logs", "maintenance_tasks_runs", column: "run_id", on_delete: :cascade
 end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -596,6 +596,14 @@ module MaintenanceTasks
       TaskJob.perform_now(run)
     end
 
+    test ".perform_now persists run logs" do
+      run = Run.create!(task_name: "Maintenance::PersistRunLogsTask")
+
+      TaskJob.perform_now(run)
+
+      assert_equal ["number: 1", "number: 2", "number: 3"], run.log.content
+    end
+
     test "Active Record Relation tasks have their count calculated implicitly" do
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
 

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -125,6 +125,17 @@ module MaintenanceTasks
       assert_predicate run.reload, :succeeded?
     end
 
+    test "#persist_transition pesists logs when the log buffer is not empty and empties the buffer" do
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask", status: "running")
+      log = ["log 1", "log 2"]
+
+      run.log_buffer = log
+      run.persist_transition
+
+      assert_equal log, run.log.content
+      assert_equal [], run.log_buffer
+    end
+
     test "#persist_progress persists increments to tick count and time_running" do
       run = Run.create!(
         task_name: "Maintenance::UpdatePostsTask",


### PR DESCRIPTION
This PR adds a new `log(message)` method that can be used inside a `#process` context. The logs will be persisted on each transition and available for download in the UI.

### Usage
```ruby
module Maintenance
  class PersistRunLogsTask < MaintenanceTasks::Task
    def collection
      [1, 2, 3]
    end

    def process(number)
      log("number: #{number}")
    end
  end
end

```
### UI
![CleanShot 2023-09-11 at 15 04 19@2x](https://github.com/holamendi/maintenance_tasks/assets/451059/4c83e614-f5df-4c69-a047-fd84421006d6)

<img width="1180" alt="CleanShot 2023-09-11 at 15 06 44@2x" src="https://github.com/holamendi/maintenance_tasks/assets/451059/982c2962-2eda-4f90-8cbc-fcd317bc4044">

